### PR TITLE
Fix typo in 'Comits should explain the..' section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ This commit is great as only one logical change was made.
 
 ### Commits should explain the change, but not be longer than 50 chars
 
-A commit message is used for quickly summarizing a change. Another contributor should be able to read it, along with the content and immediately understand the change does.
+A commit message is used for quickly summarizing a change. Another contributor should be able to read it, along with the content and immediately understand what the change does.
 
 #### Examples
 


### PR DESCRIPTION
This PR fixes a typo in the "Commits should explain the change, but not be longer than 50 chars" section of the Contribution Guidelines.
Changed:

> "understand the change does"
> to
> "understand what the change does"

This improves readability and ensures the sentence is grammatically correct.