### PR TITLE
Changed the word "chars" to "characters" to reduce ambiguity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ These should be split into one commit each.
 
 This commit is great as only one logical change was made.
 
-### Commits should explain the change, but not be longer than 50 chars
+### Commits should explain the change, but not be longer than 50 characters
 
 A commit message is used for quickly summarizing a change. Another contributor should be able to read it, along with the content and immediately understand the change does.
 


### PR DESCRIPTION
The term "chars" used in the document, while not truly ambiguous, was replaced with "characters" to make skimming/reading easier for the average visitor (assuming that they are having a CS background could be too far-fetched since a lot of students are also going to read such documents and contribute to these repositories).